### PR TITLE
Fix(OutDDCIQ): Correct msg_namelen for sendmsg() system call

### DIFF
--- a/sw_projects/P2_app/OutDDCIQ.c
+++ b/sw_projects/P2_app/OutDDCIQ.c
@@ -380,7 +380,7 @@ void *OutgoingDDCIQ(void *arg)
             datagram[DDC].msg_iov = &iovecinst[DDC];
             datagram[DDC].msg_iovlen = 1;
             datagram[DDC].msg_name = &DestAddr[DDC];                   // MAC addr & port to send to
-            datagram[DDC].msg_namelen = sizeof(DestAddr);
+            datagram[DDC].msg_namelen = sizeof(struct sockaddr_in);
         }
       //
       // enable Saturn DDC to transfer data


### PR DESCRIPTION
In OutDDCIQ.c, `DestAddr` is an array of `sockaddr_in` structures. The `msg_namelen` for `sendmsg()` was incorrectly calculated using `sizeof()` on the entire array instead of a single element.

This resulted in an oversized length being passed to the kernel. This commit corrects the argument to use `sizeof(struct sockaddr_in)`, ensuring the proper address structure size is used.