### PR TITLE
Fix(OutHighPriority): Correct variable usage for FIFO depth scaling

### DIFF
--- a/sw_projects/P2_app/OutHighPriority.c
+++ b/sw_projects/P2_app/OutHighPriority.c
@@ -153,19 +153,19 @@ void *OutgoingHighPriority(void *arg)
         FIFOOverflows |= 0b00000001;
 
       ReadFIFOMonitorChannel(eMicCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the mic FIFO Depth register
-      Word = Word*4;                                            // 4 samples per FIFO location
+      FIFOCount = FIFOCount*4;                                  // 4 samples per FIFO location
       *(uint16_t *)(UDPBuffer+33) = htons(FIFOCount);                // mic samples
       if(FIFOOverThreshold)
         FIFOOverflows |= 0b00000010;
 
       ReadFIFOMonitorChannel(eTXDUCDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the DUC FIFO Depth register
-      Word = (Word*4)/3;                                        // 4/3 samples per FIFO location
+      FIFOCount = (FIFOCount*4)/3;                              // 4/3 samples per FIFO location
       *(uint16_t *)(UDPBuffer+35) = htons(FIFOCount);                // DUC samples
       if(FIFOUnderflow)
         FIFOOverflows |= 0b00000100;
 
       ReadFIFOMonitorChannel(eSpkCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the speaker FIFO Depth register
-      Word = Word*2;                                            // 2 samples per FIFO location
+      FIFOCount = FIFOCount*2;                                  // 2 samples per FIFO location
       *(uint16_t *)(UDPBuffer+37) = htons(FIFOCount);                // speaker samples
       if(FIFOUnderflow)
         FIFOOverflows |= 0b00001000;


### PR DESCRIPTION
In OutHighPriority.c, when preparing high-priority status packets, the code intended to scale FIFOCount values from hardware "locations" to "samples". However, it mistakenly used the stale Word variable (containing the last analog input reading) in the scaling calculations instead of FIFOCount.

This means the scaling calculations are done on irrelevant analog data.

To fix, we change the incorrect Word usage with FIFOCount.