### PR TITLE
Fix: Eliminate unaligned memory access in network packet parsing

### DIFF
--- a/sw_projects/P2_app/IncomingDDCSpecific.c
+++ b/sw_projects/P2_app/IncomingDDCSpecific.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "../common/saturnregisters.h"
+#include "../common/byteio.h"
 #include "OutDDCIQ.h"
 #include <pthread.h>
 #include <syscall.h>
@@ -96,13 +97,12 @@ void *IncomingDDCSpecific(void *arg)                    // listener thread
       // reuse "random" for DDC enabled.
       // be aware an interleaved "odd" DDC will usually be set to disabled, and we need to revert this!
       //
-      Word = *(uint16_t*)(UDPInBuffer + 7);                 // get DDC enables 15:0 (note it is already low byte 1st!)
+      Word = rd_le_u16(UDPInBuffer + 7);                   // get DDC enables 15:0 (note it is already low byte 1st!)
       for(i=0; i<VNUMDDC; i++)
       {
         Enabled = (bool)(Word & 1);                        // get enable state
         Byte1 = *(uint8_t*)(UDPInBuffer+i*6+17);          // get ADC for this DDC
-        Word2 = *(uint16_t*)(UDPInBuffer+i*6+18);         // get sample rate for this DDC
-        Word2 = ntohs(Word2);                             // swap byte order
+        Word2 = rd_be_u16(UDPInBuffer+i*6+18);            // get sample rate for this DDC
         Byte2 = *(uint8_t*)(UDPInBuffer+i*6+22);          // get sample size for this DDC
         SetDDCSampleSize(i, Byte2);
         if(Byte1 == 0)

--- a/sw_projects/P2_app/IncomingDUCSpecific.c
+++ b/sw_projects/P2_app/IncomingDUCSpecific.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "../common/saturnregisters.h"
+#include "../common/byteio.h"
 #include <pthread.h>
 #include <syscall.h>
 
@@ -88,13 +89,11 @@ void *IncomingDUCSpecific(void *arg)                    // listener thread
           SetCWSidetoneEnabled((bool)((Byte >> 4)&1));
           EnableCW((bool)((Byte >> 1)&1), (bool)((Byte >> 7)&1));   // CW enabled bit, breakin bit
           SidetoneVolume = *(uint8_t*)(UDPInBuffer+6);            // keyer speed
-          SidetoneFreq = *(uint16_t*)(UDPInBuffer+7);             // get frequency
-          SidetoneFreq = ntohs(SidetoneFreq);                     // convert from big endian
+          SidetoneFreq = rd_be_u16(UDPInBuffer+7);                // get frequency
           SetCWSidetoneVol(SidetoneVolume);
           SetCWSidetoneFrequency(SidetoneFreq);
           CWRFDelay = *(uint8_t*)(UDPInBuffer+13);                // delay before CW on
-          CWHangDelay = *(uint16_t*)(UDPInBuffer+11);             // delay before CW off
-          CWHangDelay = ntohs(CWHangDelay);                       // convert from big endian
+          CWHangDelay = rd_be_u16(UDPInBuffer+11);                // delay before CW off
           SetCWPTTDelay(CWRFDelay);
           SetCWHangTime(CWHangDelay);
           CWRampTime = *(uint8_t*)(UDPInBuffer+17);               // ramp transition time

--- a/sw_projects/P2_app/OutHighPriority.c
+++ b/sw_projects/P2_app/OutHighPriority.c
@@ -28,6 +28,7 @@
 #include <syscall.h>
 #include "../common/saturnregisters.h"
 #include "../common/saturndrivers.h"
+#include "../common/byteio.h"
 #include "LDGATU.h"
 
 
@@ -125,18 +126,18 @@ void *OutgoingHighPriority(void *arg)
       *(uint8_t *)(UDPBuffer+5) = ADCOverflows;
       ADCOverflows = 0;                                         // and clear ready for next test
       Word = (uint16_t)GetAnalogueIn(4);
-      *(uint16_t *)(UDPBuffer+6) = htons(Word);                // exciter power
+      wr_be_u16(UDPBuffer+6, Word);                     // exciter power
       Word = (uint16_t)GetAnalogueIn(0);
-      *(uint16_t *)(UDPBuffer+14) = htons(Word);               // forward power
+      wr_be_u16(UDPBuffer+14, Word);                    // forward power
       Word = (uint16_t)GetAnalogueIn(1);
-      *(uint16_t *)(UDPBuffer+22) = htons(Word);               // reverse power
+      wr_be_u16(UDPBuffer+22, Word);                    // reverse power
       Word = (uint16_t)GetAnalogueIn(5);
-      *(uint16_t *)(UDPBuffer+49) = htons(Word);               // supply voltage
+      wr_be_u16(UDPBuffer+49, Word);                    // supply voltage
 
       Word = (uint16_t)GetAnalogueIn(2);
-      *(uint16_t *)(UDPBuffer+57) = htons(Word);               // AIN3 user_analog1
+      wr_be_u16(UDPBuffer+57, Word);                    // AIN3 user_analog1
       Word = (uint16_t)GetAnalogueIn(3);
-      *(uint16_t *)(UDPBuffer+55) = htons(Word);               // AIN4 user_analog2
+      wr_be_u16(UDPBuffer+55, Word);                    // AIN4 user_analog2
 
       Byte = (uint8_t)GetUserIOBits();                  // user I/O bits
       *(uint8_t *)(UDPBuffer+59) = Byte;
@@ -148,25 +149,25 @@ void *OutgoingHighPriority(void *arg)
 //
       FIFOOverflows = 0;
       ReadFIFOMonitorChannel(eRXDDCDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the DDC FIFO Depth register
-      *(uint16_t *)(UDPBuffer+31) = htons(FIFOCount);                // DDC ssmples
+      wr_be_u16(UDPBuffer+31, FIFOCount);                       // DDC samples
       if(FIFOOverThreshold)
         FIFOOverflows |= 0b00000001;
 
       ReadFIFOMonitorChannel(eMicCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the mic FIFO Depth register
       Word = Word*4;                                            // 4 samples per FIFO location
-      *(uint16_t *)(UDPBuffer+33) = htons(FIFOCount);                // mic samples
+      wr_be_u16(UDPBuffer+33, FIFOCount);                       // mic samples
       if(FIFOOverThreshold)
         FIFOOverflows |= 0b00000010;
 
       ReadFIFOMonitorChannel(eTXDUCDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the DUC FIFO Depth register
       Word = (Word*4)/3;                                        // 4/3 samples per FIFO location
-      *(uint16_t *)(UDPBuffer+35) = htons(FIFOCount);                // DUC samples
+      wr_be_u16(UDPBuffer+35, FIFOCount);                       // DUC samples
       if(FIFOUnderflow)
         FIFOOverflows |= 0b00000100;
 
       ReadFIFOMonitorChannel(eSpkCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &FIFOCount);				// read the speaker FIFO Depth register
       Word = Word*2;                                            // 2 samples per FIFO location
-      *(uint16_t *)(UDPBuffer+37) = htons(FIFOCount);                // speaker samples
+      wr_be_u16(UDPBuffer+37, FIFOCount);                       // speaker samples
       if(FIFOUnderflow)
         FIFOOverflows |= 0b00001000;
 

--- a/sw_projects/P2_app/generalpacket.c
+++ b/sw_projects/P2_app/generalpacket.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include "generalpacket.h"
 #include "../common/saturnregisters.h"
+#include "../common/byteio.h"
 #include "Outwideband.h"
 
 
@@ -42,16 +43,16 @@ int HandleGeneralPacket(uint8_t *PacketBuffer)
   int i;
   uint8_t Byte;
 
-  SetPort(VPORTDDCSPECIFIC, ntohs(*(uint16_t*)(PacketBuffer+5)));
-  SetPort(VPORTDUCSPECIFIC, ntohs(*(uint16_t*)(PacketBuffer+7)));
-  SetPort(VPORTHIGHPRIORITYTOSDR, ntohs(*(uint16_t*)(PacketBuffer+9)));
-  SetPort(VPORTSPKRAUDIO, ntohs(*(uint16_t*)(PacketBuffer+13)));
-  SetPort(VPORTDUCIQ, ntohs(*(uint16_t*)(PacketBuffer+15)));
-  SetPort(VPORTHIGHPRIORITYFROMSDR, ntohs(*(uint16_t*)(PacketBuffer+11)));
-  SetPort(VPORTMICAUDIO, ntohs(*(uint16_t*)(PacketBuffer+19)));
+  SetPort(VPORTDDCSPECIFIC, rd_be_u16(PacketBuffer+5));
+  SetPort(VPORTDUCSPECIFIC, rd_be_u16(PacketBuffer+7));
+  SetPort(VPORTHIGHPRIORITYTOSDR, rd_be_u16(PacketBuffer+9));
+  SetPort(VPORTSPKRAUDIO, rd_be_u16(PacketBuffer+13));
+  SetPort(VPORTDUCIQ, rd_be_u16(PacketBuffer+15));
+  SetPort(VPORTHIGHPRIORITYFROMSDR, rd_be_u16(PacketBuffer+11));
+  SetPort(VPORTMICAUDIO, rd_be_u16(PacketBuffer+19));
 
 // DDC ports start at the transferred value then increment
-  Port = ntohs(*(uint16_t*)(PacketBuffer+17));            // DDC0
+  Port = rd_be_u16(PacketBuffer+17);            // DDC0
   for (i=0; i<10; i++)
   {
     if(Port==0)
@@ -61,7 +62,7 @@ int HandleGeneralPacket(uint8_t *PacketBuffer)
   }  
 
 // similarly, wideband ports start at the transferred value then increment
-  Port = ntohs(*(uint16_t*)(PacketBuffer+21));            // DDC0
+  Port = rd_be_u16(PacketBuffer+21);            // Wideband0
   for (i=0; i<2; i++)
   {
     if(Port==0)
@@ -74,18 +75,18 @@ int HandleGeneralPacket(uint8_t *PacketBuffer)
 // wideband capture data:
 //
   WidebandEnables = *(uint8_t*)(PacketBuffer+23);                // get wideband enables
-  WidebandSampleCount = ntohs(*(uint16_t*)(PacketBuffer+24));        // wideband sample count
-  WidebandSampleSize = *(uint8_t*)(PacketBuffer+26);                // wideband sample size
-  WidebandUpdateRate = *(uint8_t*)(PacketBuffer+27);                // wideband update rate
-  WidebandPacketsPerFrame = *(uint8_t*)(PacketBuffer+28);                // wideband packets per frame
+  WidebandSampleCount = rd_be_u16(PacketBuffer+24);              // wideband sample count
+  WidebandSampleSize = *(uint8_t*)(PacketBuffer+26);             // wideband sample size
+  WidebandUpdateRate = *(uint8_t*)(PacketBuffer+27);             // wideband update rate
+  WidebandPacketsPerFrame = *(uint8_t*)(PacketBuffer+28);        // wideband packets per frame
   SetWidebandParams(WidebandEnables, WidebandSampleCount, WidebandSampleSize, WidebandUpdateRate, WidebandPacketsPerFrame);
 
 //
 // envelope PWM data:
 //
-  Port = ntohs(*(uint16_t*)(PacketBuffer+33));        // PWM min
+  Port = rd_be_u16(PacketBuffer+33);        // PWM min
   SetMinPWMWidth(Port);
-  Port = ntohs(*(uint16_t*)(PacketBuffer+35));        // PWM max
+  Port = rd_be_u16(PacketBuffer+35);        // PWM max
   SetMaxPWMWidth(Port);
 //
 // various bits

--- a/sw_projects/common/byteio.h
+++ b/sw_projects/common/byteio.h
@@ -1,0 +1,67 @@
+#ifndef SATURN_BYTEIO_H
+#define SATURN_BYTEIO_H
+
+#include <stdint.h>
+#include <string.h>   // memcpy
+#include <arpa/inet.h> // htons/htonl/ntohs/ntohl
+
+#if defined(__GNUC__) || defined(__clang__)
+  #define SATURN_INLINE static __inline__ __attribute__((always_inline))
+#else
+  #define SATURN_INLINE static inline
+#endif
+
+/*
+ * Safe byte I/O helpers for unaligned memory access in network packets.
+ * These functions use memcpy to avoid undefined behavior from casting
+ * unaligned pointers, which can cause performance/odd behavior issues
+ * or even crashes on ARM architectures.
+ */
+
+/* Read big-endian values from potentially unaligned buffers */
+SATURN_INLINE uint16_t rd_be_u16(const void *p) {
+    uint16_t v;
+    memcpy(&v, p, sizeof(v));
+    return ntohs(v);
+}
+
+SATURN_INLINE uint32_t rd_be_u32(const void *p) {
+    uint32_t v;
+    memcpy(&v, p, sizeof(v));
+    return ntohl(v);
+}
+
+/* Read little-endian values from potentially unaligned buffers */
+SATURN_INLINE uint16_t rd_le_u16(const void *p) {
+    uint16_t v;
+    memcpy(&v, p, sizeof(v));
+    return v; // Already in host byte order
+}
+
+SATURN_INLINE uint32_t rd_le_u32(const void *p) {
+    uint32_t v;
+    memcpy(&v, p, sizeof(v));
+    return v; // Already in host byte order
+}
+
+/* Write big-endian values to potentially unaligned buffers */
+SATURN_INLINE void wr_be_u16(void *p, uint16_t val) {
+    uint16_t v = htons(val);
+    memcpy(p, &v, sizeof(v));
+}
+
+SATURN_INLINE void wr_be_u32(void *p, uint32_t val) {
+    uint32_t v = htonl(val);
+    memcpy(p, &v, sizeof(v));
+}
+
+/* Write little-endian values to potentially unaligned buffers */
+SATURN_INLINE void wr_le_u16(void *p, uint16_t val) {
+    memcpy(p, &val, sizeof(val));
+}
+
+SATURN_INLINE void wr_le_u32(void *p, uint32_t val) {
+    memcpy(p, &val, sizeof(val));
+}
+
+#endif /* SATURN_BYTEIO_H */


### PR DESCRIPTION
In multiple places, the code performs undefined behavior by casting unaligned byte buffer offsets to uint16_t* and uint32_t* pointers and dereferencing them directly. This is undefined behavior per the C standard.

The safe byte I/O helpers use memcpy to eliminate the UB and will introduce no performance loss.