### PR TITLE
Fix: Add mutex protection to prevent race condition on GlobalFIFOOverflows

### DIFF
--- a/sw_projects/P2_app/InDUCIQ.c
+++ b/sw_projects/P2_app/InDUCIQ.c
@@ -138,7 +138,9 @@ void *IncomingDUCIQ(void *arg)                          // listener thread
 
             if((StartupCount == 0) && FIFOUnderflow)
             {
+                pthread_mutex_lock(&g_fifo_overflow_mutex);
                 GlobalFIFOOverflows |= 0b00000100;
+                pthread_mutex_unlock(&g_fifo_overflow_mutex);
                 if(UseDebug)
                     printf("TX DUC FIFO Underflowed, depth now = %d\n", Current);
             }
@@ -151,7 +153,9 @@ void *IncomingDUCIQ(void *arg)                          // listener thread
                     printf("TX DUC FIFO Overthreshold, depth now = %d\n", Current);
                 if((StartupCount == 0) && FIFOUnderflow)
                 {
+                    pthread_mutex_lock(&g_fifo_overflow_mutex);
                     GlobalFIFOOverflows |= 0b00000100;
+                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
                     if(UseDebug)
                         printf("TX DUC FIFO Underflowed, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/InSpkrAudio.c
+++ b/sw_projects/P2_app/InSpkrAudio.c
@@ -135,7 +135,9 @@ void *IncomingSpkrAudio(void *arg)                      // listener thread
                 printf("Codec speaker FIFO Overthreshold, depth now = %d\n", Current);
             if((StartupCount == 0) && FIFOUnderflow)
             {
+                pthread_mutex_lock(&g_fifo_overflow_mutex);
                 GlobalFIFOOverflows |= 0b00001000;
+                pthread_mutex_unlock(&g_fifo_overflow_mutex);
                 if(UseDebug)
                     printf("Codec speaker FIFO Underflowed, depth now = %d\n", Current);
             }
@@ -148,7 +150,9 @@ void *IncomingSpkrAudio(void *arg)                      // listener thread
                     printf("Codec speaker FIFO Overthreshold, depth now = %d\n", Current);
                 if((StartupCount == 0) && FIFOUnderflow)
                 {
+                    pthread_mutex_lock(&g_fifo_overflow_mutex);
                     GlobalFIFOOverflows |= 0b00001000;
+                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
                     if(UseDebug)
                         printf("Codec speaker FIFO Underflowed, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/OutDDCIQ.c
+++ b/sw_projects/P2_app/OutDDCIQ.c
@@ -454,7 +454,9 @@ void *OutgoingDDCIQ(void *arg)
 
             if((StartupCount == 0) && FIFOOverThreshold)
             {
+                pthread_mutex_lock(&g_fifo_overflow_mutex);
                 GlobalFIFOOverflows |= 0b00000001;
+                pthread_mutex_unlock(&g_fifo_overflow_mutex);
                 if(UseDebug)
                     printf("RX DDC FIFO Overthreshold, depth now = %d\n", Current);
             }
@@ -469,7 +471,9 @@ void *OutgoingDDCIQ(void *arg)
                 Depth = ReadFIFOMonitorChannel(eRXDDCDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &Current);				// read the FIFO Depth register
                 if((StartupCount == 0) && FIFOOverThreshold)
                 {
+                    pthread_mutex_lock(&g_fifo_overflow_mutex);
                     GlobalFIFOOverflows |= 0b00000001;
+                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
                     if(UseDebug)
                         printf("RX DDC FIFO Overthreshold, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/OutMicAudio.c
+++ b/sw_projects/P2_app/OutMicAudio.c
@@ -167,7 +167,9 @@ void *OutgoingMicSamples(void *arg)
             Depth = ReadFIFOMonitorChannel(eMicCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &Current);			// read the FIFO Depth register. 4 mic words per 64 bit word.
             if((StartupCount == 0) && FIFOOverThreshold)
             {
+                pthread_mutex_lock(&g_fifo_overflow_mutex);
                 GlobalFIFOOverflows |= 0b00000010;
+                pthread_mutex_unlock(&g_fifo_overflow_mutex);
                 if(UseDebug)
                     printf("Codec Mic FIFO Overthreshold, depth now = %d\n", Current);
             }
@@ -182,7 +184,9 @@ void *OutgoingMicSamples(void *arg)
                 Depth = ReadFIFOMonitorChannel(eMicCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &Current);				// read the FIFO Depth register
                 if((StartupCount == 0) && FIFOOverThreshold)
                 {
+                    pthread_mutex_lock(&g_fifo_overflow_mutex);
                     GlobalFIFOOverflows |= 0b00000010;
+                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
                     if(UseDebug)
                         printf("Codec Mic FIFO Overthreshold, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/threaddata.h
+++ b/sw_projects/P2_app/threaddata.h
@@ -79,6 +79,7 @@ extern bool NewMessageReceived;                     // set whenever a message is
 extern bool ThreadError;                            // set true if a thread reports an error
 extern bool UseDebug;                               // true if debugging enabled
 extern uint8_t GlobalFIFOOverflows;                 // FIFO overflow words
+extern pthread_mutex_t g_fifo_overflow_mutex;       // protect GlobalFIFOOverflows from race conditions
 extern sem_t MicWBDMAMutex;                         // protect one DMA read channel shared by mic and WB read
 
 


### PR DESCRIPTION
The GlobalFIFOOverflows variable is accessed by multiple threads without synchronization, which causes critical race conditions:

- Multiple threads performance non-athomic read-modify-write operations (|=) could lose overflow flags when writing simultaneously.
- The OutHighPriority thread's read-and-clear operation could lose overflow flags set between the read and clear operations.
- Lost overflow flags means FIFO errors go unreported, potentially causing problems.

To fix, the solution is to add pthread_mutex_t g_fifo_overflow_mutex with static initialization, and then protect the 12 access points with mutex lock/unlock operations. This ensures atomic read-and-clear operations in OutHighPriority thread, and follows the existing pattern of using pthread mutexes for shared resource concurrency.