### PR TITLE
refactor: use atomic for GlobalFIFOOverflows

### DIFF
--- a/sw_projects/P2_app/InDUCIQ.c
+++ b/sw_projects/P2_app/InDUCIQ.c
@@ -138,9 +138,7 @@ void *IncomingDUCIQ(void *arg)                          // listener thread
 
             if((StartupCount == 0) && FIFOUnderflow)
             {
-                pthread_mutex_lock(&g_fifo_overflow_mutex);
-                GlobalFIFOOverflows |= 0b00000100;
-                pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                atomic_fetch_or(&GlobalFIFOOverflows, 0b00000100);
                 if(UseDebug)
                     printf("TX DUC FIFO Underflowed, depth now = %d\n", Current);
             }
@@ -153,9 +151,7 @@ void *IncomingDUCIQ(void *arg)                          // listener thread
                     printf("TX DUC FIFO Overthreshold, depth now = %d\n", Current);
                 if((StartupCount == 0) && FIFOUnderflow)
                 {
-                    pthread_mutex_lock(&g_fifo_overflow_mutex);
-                    GlobalFIFOOverflows |= 0b00000100;
-                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                    atomic_fetch_or(&GlobalFIFOOverflows, 0b00000100);
                     if(UseDebug)
                         printf("TX DUC FIFO Underflowed, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/InSpkrAudio.c
+++ b/sw_projects/P2_app/InSpkrAudio.c
@@ -135,9 +135,7 @@ void *IncomingSpkrAudio(void *arg)                      // listener thread
                 printf("Codec speaker FIFO Overthreshold, depth now = %d\n", Current);
             if((StartupCount == 0) && FIFOUnderflow)
             {
-                pthread_mutex_lock(&g_fifo_overflow_mutex);
-                GlobalFIFOOverflows |= 0b00001000;
-                pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                atomic_fetch_or(&GlobalFIFOOverflows, 0b00001000);
                 if(UseDebug)
                     printf("Codec speaker FIFO Underflowed, depth now = %d\n", Current);
             }
@@ -150,9 +148,7 @@ void *IncomingSpkrAudio(void *arg)                      // listener thread
                     printf("Codec speaker FIFO Overthreshold, depth now = %d\n", Current);
                 if((StartupCount == 0) && FIFOUnderflow)
                 {
-                    pthread_mutex_lock(&g_fifo_overflow_mutex);
-                    GlobalFIFOOverflows |= 0b00001000;
-                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                    atomic_fetch_or(&GlobalFIFOOverflows, 0b00001000);
                     if(UseDebug)
                         printf("Codec speaker FIFO Underflowed, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/OutDDCIQ.c
+++ b/sw_projects/P2_app/OutDDCIQ.c
@@ -454,9 +454,7 @@ void *OutgoingDDCIQ(void *arg)
 
             if((StartupCount == 0) && FIFOOverThreshold)
             {
-                pthread_mutex_lock(&g_fifo_overflow_mutex);
-                GlobalFIFOOverflows |= 0b00000001;
-                pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                atomic_fetch_or(&GlobalFIFOOverflows, 0b00000001);
                 if(UseDebug)
                     printf("RX DDC FIFO Overthreshold, depth now = %d\n", Current);
             }
@@ -471,9 +469,7 @@ void *OutgoingDDCIQ(void *arg)
                 Depth = ReadFIFOMonitorChannel(eRXDDCDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &Current);				// read the FIFO Depth register
                 if((StartupCount == 0) && FIFOOverThreshold)
                 {
-                    pthread_mutex_lock(&g_fifo_overflow_mutex);
-                    GlobalFIFOOverflows |= 0b00000001;
-                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                    atomic_fetch_or(&GlobalFIFOOverflows, 0b00000001);
                     if(UseDebug)
                         printf("RX DDC FIFO Overthreshold, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/OutMicAudio.c
+++ b/sw_projects/P2_app/OutMicAudio.c
@@ -167,9 +167,7 @@ void *OutgoingMicSamples(void *arg)
             Depth = ReadFIFOMonitorChannel(eMicCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &Current);			// read the FIFO Depth register. 4 mic words per 64 bit word.
             if((StartupCount == 0) && FIFOOverThreshold)
             {
-                pthread_mutex_lock(&g_fifo_overflow_mutex);
-                GlobalFIFOOverflows |= 0b00000010;
-                pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                atomic_fetch_or(&GlobalFIFOOverflows, 0b00000010);
                 if(UseDebug)
                     printf("Codec Mic FIFO Overthreshold, depth now = %d\n", Current);
             }
@@ -184,9 +182,7 @@ void *OutgoingMicSamples(void *arg)
                 Depth = ReadFIFOMonitorChannel(eMicCodecDMA, &FIFOOverflow, &FIFOOverThreshold, &FIFOUnderflow, &Current);				// read the FIFO Depth register
                 if((StartupCount == 0) && FIFOOverThreshold)
                 {
-                    pthread_mutex_lock(&g_fifo_overflow_mutex);
-                    GlobalFIFOOverflows |= 0b00000010;
-                    pthread_mutex_unlock(&g_fifo_overflow_mutex);
+                    atomic_fetch_or(&GlobalFIFOOverflows, 0b00000010);
                     if(UseDebug)
                         printf("Codec Mic FIFO Overthreshold, depth now = %d\n", Current);
                 }

--- a/sw_projects/P2_app/threaddata.h
+++ b/sw_projects/P2_app/threaddata.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <netinet/in.h>
+#include <stdatomic.h>
 #include "../common/saturntypes.h"
 #include <semaphore.h>
 
@@ -78,8 +79,7 @@ extern bool StartBitReceived;                       // true when "run" bit has b
 extern bool NewMessageReceived;                     // set whenever a message is received
 extern bool ThreadError;                            // set true if a thread reports an error
 extern bool UseDebug;                               // true if debugging enabled
-extern uint8_t GlobalFIFOOverflows;                 // FIFO overflow words
-extern pthread_mutex_t g_fifo_overflow_mutex;       // protect GlobalFIFOOverflows from race conditions
+extern atomic_uint_fast8_t GlobalFIFOOverflows;     // FIFO overflow flags (atomic)
 extern sem_t MicWBDMAMutex;                         // protect one DMA read channel shared by mic and WB read
 
 


### PR DESCRIPTION
Replace all GlobalFIFOOverflows mutex operations with atomic operations:
- Use atomic_fetch_or() for writers (DDC/DUC/mic/speaker threads)
- Use atomic_exchange() for read-and-clear in OutHighPriority
- Remove all pthread_mutex_lock/unlock calls for g_fifo_overflow_mutex
- Add <stdatomic.h> header includes via threaddata.h

This is simpler & removes residual syscall overhead from high-frequency streaming paths.