### PR TITLE
p2app: SPE Expert amp CAT emulation (-e option)

### DIFF
--- a/sw_projects/P2_app/InHighPriority.c
+++ b/sw_projects/P2_app/InHighPriority.c
@@ -29,6 +29,7 @@
 #include "../common/byteio.h"
 #include "cathandler.h"
 #include "AriesATU.h"
+#include "SPEAmpControl.h"
 #include <pthread.h>
 #include <syscall.h>
 
@@ -109,6 +110,7 @@ void *IncomingHighPriority(void *arg)                   // listener thread
         SetTXEnable(false);
         IsTXMode = false;
         SetMOX(false);
+        SetSPEAmpTXState(false);
         EnableCW(false, false);
         printf("set to inactive by client app\n");
         StartBitReceived = false;
@@ -118,6 +120,7 @@ void *IncomingHighPriority(void *arg)                   // listener thread
       //
       IsTXMode = (bool)(Byte&2);
       SetMOX(IsTXMode);
+      SetSPEAmpTXState(IsTXMode);
 
 //
 // now properly decode DDC frequencies
@@ -136,6 +139,7 @@ void *IncomingHighPriority(void *arg)                   // listener thread
       LongWord = rd_be_u32(UDPInBuffer+329);
       SetDUCFrequency(LongWord, true);
       SetAriesTXFrequency(LongWord);
+      SetSPEAmpTXFrequency(LongWord);
       Byte = (uint8_t)(UDPInBuffer[345]);
       SetTXDriveLevel(Byte);
       //

--- a/sw_projects/P2_app/Makefile
+++ b/sw_projects/P2_app/Makefile
@@ -15,7 +15,7 @@ TARGET = p2app
 VPATH=.:../common
 GIT_DATE := $(wordlist 2,5, $(shell git log -1 --format=%cd --date=rfc))
 
-SRCS = $(TARGET).c hwaccess.c saturnregisters.c codecwrite.c saturndrivers.c version.c generalpacket.c IncomingDDCSpecific.c  IncomingDUCSpecific.c InHighPriority.c InDUCIQ.c InSpkrAudio.c OutMicAudio.c OutDDCIQ.c OutHighPriority.c debugaids.c auxadc.c cathandler.c frontpanelhandler.c catmessages.c g2panel.c LDGATU.c g2v2panel.c i2cdriver.c andromedacatmessages.c Outwideband.c serialport.c AriesATU.c GanymedePAControl.c
+SRCS = $(TARGET).c hwaccess.c saturnregisters.c codecwrite.c saturndrivers.c version.c generalpacket.c IncomingDDCSpecific.c  IncomingDUCSpecific.c InHighPriority.c InDUCIQ.c InSpkrAudio.c OutMicAudio.c OutDDCIQ.c OutHighPriority.c debugaids.c auxadc.c cathandler.c frontpanelhandler.c catmessages.c g2panel.c LDGATU.c g2v2panel.c i2cdriver.c andromedacatmessages.c Outwideband.c serialport.c AriesATU.c GanymedePAControl.c SPEAmpControl.c
 OBJS = $(SRCS:.c=.o)
 
 # for cppcheck

--- a/sw_projects/P2_app/SPEAmpControl.c
+++ b/sw_projects/P2_app/SPEAmpControl.c
@@ -1,0 +1,329 @@
+/////////////////////////////////////////////////////////////
+//
+// Saturn project: Artix7 FPGA + Raspberry Pi4 Compute Module
+// PCI Express interface from linux on Raspberry pi
+// this application uses C code to emulate HPSDR protocol 2
+//
+// copyright Laurence Barker November 2021
+// licenced under GNU GPL3
+//
+// SPEAmpControl.c:
+//
+// Kenwood TS-2000 CAT emulation for SPE Expert linear amplifiers.
+// Handles IF; and FA; queries on a serial tty using the current TX
+// frequency from the DUC delta-phase word.
+//
+//////////////////////////////////////////////////////////////
+
+#include "SPEAmpControl.h"
+#include "serialport.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <termios.h>
+#include <pthread.h>
+#include <syscall.h>
+#include <errno.h>
+
+
+// default serial baud rate
+#define SPE_DEFAULT_BAUD  B9600
+
+// maximum length of an incoming CAT command (e.g. "IF;")
+#define SPE_INBUF_SIZE    32
+
+// TX frequency in Hz, updated by SetSPEAmpTXFrequency()
+static uint32_t SPETXFreq_Hz = 0;
+
+// scaling factor: DUC delta-phase word -> Hz (same as AriesATU.c)
+// f_Hz = phase * (122880000 / 2^32) = phase * 0.028610229...
+#define SPE_DELTAPHASE_TO_HZ  0.028610229
+
+bool SPEAmpActive = false;
+
+static pthread_t         SPEThread;
+static bool              SPEThreadStarted = false;
+static int               SPESerialFd = -1;
+static bool              SPETXState = false;
+static pthread_mutex_t   SPEStateMutex = PTHREAD_MUTEX_INITIALIZER;
+
+
+// Send a TS-2000 IF response. Fields not tracked by p2app are set to
+// neutral defaults; the SPE Expert only needs the frequency and TX/RX bit.
+// Mode is hardcoded to USB for now.
+static void SPESendIF(int fd, uint32_t freq_hz, bool is_tx)
+{
+    char buf[64];
+    int len;
+
+    len = snprintf(buf, sizeof(buf),
+        "IF%011u"   // freq (11 digits)
+        " 0000"     // step: 1 space + 4 digits (TS-2000 default step repr)
+        "+0000"     // RIT sign + offset (4 digits)
+        "00"        // RIT on, XIT on
+        "00"        // memory channel (2 digits)
+        "%c"        // TX/RX: '1' = TX, '0' = RX
+        "2"         // mode: USB
+        "0"         // VFO: A
+        "0"         // scan: off
+        "0"         // split: off
+        "0"         // tone: off
+        "00"        // tone number (2 digits)
+        ";",
+        freq_hz,
+        is_tx ? '1' : '0');
+
+    if (len > 0)
+        write(fd, buf, (size_t)len);
+}
+
+
+//
+// Build and send a Kenwood FA (VFO-A frequency) response.
+// Format: FA[11-digit freq];
+//
+static void SPESendFA(int fd, uint32_t freq_hz)
+{
+    char buf[32];
+    int len;
+
+    len = snprintf(buf, sizeof(buf), "FA%011u;", freq_hz);
+    if (len > 0)
+        write(fd, buf, (size_t)len);
+}
+
+
+//
+// Parse the command that arrived in cmd[] (null-terminated, without the
+// trailing semicolon) and dispatch to the appropriate response sender.
+//
+static void SPEDispatch(int fd, const char *cmd)
+{
+    uint32_t freq;
+    bool tx;
+
+    pthread_mutex_lock(&SPEStateMutex);
+    freq = SPETXFreq_Hz;
+    tx = SPETXState;
+    pthread_mutex_unlock(&SPEStateMutex);
+
+    if (strcmp(cmd, "IF") == 0)
+    {
+        SPESendIF(fd, freq, tx);
+    }
+    else if (strcmp(cmd, "FA") == 0)
+    {
+        SPESendFA(fd, freq);
+    }
+    // All other commands are silently ignored; the amp will retry or
+    // move on.  Adding responses for further commands (e.g. MD;, AI;)
+    // is straightforward: extend this if/else chain.
+}
+
+
+//
+// SPEAmpThreadFunction()
+// Reads bytes from the serial port, assembles them into semicolon-terminated
+// commands, and calls SPEDispatch() for each complete command.
+//
+static void* SPEAmpThreadFunction(__attribute__((unused)) void *arg)
+{
+    char inbuf[SPE_INBUF_SIZE];
+    int  inptr = 0;
+    char rawbuf[SPE_INBUF_SIZE];
+    int  nread;
+    int  i;
+    char ch;
+
+    printf("SPE amp CAT thread started, pid=%ld\n", syscall(SYS_gettid));
+
+    while (true)
+    {
+        pthread_mutex_lock(&SPEStateMutex);
+        if (!SPEAmpActive)
+        {
+            pthread_mutex_unlock(&SPEStateMutex);
+            break;
+        }
+        pthread_mutex_unlock(&SPEStateMutex);
+
+        nread = read(SPESerialFd, rawbuf, sizeof(rawbuf) - 1);
+        if (nread <= 0)
+        {
+            if (nread < 0 && errno != EINTR)
+                break;
+            continue;
+        }
+
+        for (i = 0; i < nread; i++)
+        {
+            ch = rawbuf[i];
+
+            if (ch == ';')
+            {
+                // end of command: null-terminate and dispatch
+                inbuf[inptr] = '\0';
+                if (inptr > 0)
+                    SPEDispatch(SPESerialFd, inbuf);
+                inptr = 0;
+            }
+            else if (ch >= ' ')
+            {
+                // accumulate printable characters only
+                if (inptr < (SPE_INBUF_SIZE - 1))
+                    inbuf[inptr++] = ch;
+                else
+                    inptr = 0;  // overflow: discard and restart
+            }
+            // control characters other than ';' are silently dropped
+        }
+    }
+
+    printf("SPE amp CAT thread stopped\n");
+    return NULL;
+}
+
+
+//
+// Parse optional ":baudrate" suffix from PathAndBaud, open the port,
+// and translate the integer baud to a termios speed constant.
+//
+static unsigned int ParseBaud(const char *baudstr)
+{
+    int b = atoi(baudstr);
+    switch (b)
+    {
+        case 1200:   return B1200;
+        case 2400:   return B2400;
+        case 4800:   return B4800;
+        case 9600:   return B9600;
+        case 19200:  return B19200;
+        case 38400:  return B38400;
+        case 57600:  return B57600;
+        case 115200: return B115200;
+        default:
+            printf("SPEAmpControl: unrecognised baud rate %d, using 9600\n", b);
+            return B9600;
+    }
+}
+
+
+//
+// InitialiseSPEAmpHandler()
+// Parse PathAndBaud, open the serial port, start the listener thread.
+// Returns true on success.
+//
+bool InitialiseSPEAmpHandler(const char *PathAndBaud)
+{
+    char        path[160];
+    unsigned int baud = SPE_DEFAULT_BAUD;
+    const char *colon;
+    int result;
+
+    // split "path:baud" or plain "path"
+    colon = strchr(PathAndBaud, ':');
+    if (colon != NULL)
+    {
+        size_t pathlen = (size_t)(colon - PathAndBaud);
+        if (pathlen >= sizeof(path))
+            pathlen = sizeof(path) - 1;
+        strncpy(path, PathAndBaud, pathlen);
+        path[pathlen] = '\0';
+        baud = ParseBaud(colon + 1);
+    }
+    else
+    {
+        strncpy(path, PathAndBaud, sizeof(path) - 1);
+        path[sizeof(path) - 1] = '\0';
+    }
+
+    SPESerialFd = OpenSerialPort(path, baud);
+    if (SPESerialFd == -1)
+    {
+        printf("SPE amp CAT: failed to open serial port %s\n", path);
+        return false;
+    }
+
+    pthread_mutex_lock(&SPEStateMutex);
+    SPEAmpActive = true;
+    SPEThreadStarted = false;
+    pthread_mutex_unlock(&SPEStateMutex);
+
+    result = pthread_create(&SPEThread, NULL, SPEAmpThreadFunction, NULL);
+    if (result != 0)
+    {
+        errno = result;
+        perror("pthread_create SPE amp CAT thread");
+        pthread_mutex_lock(&SPEStateMutex);
+        SPEAmpActive = false;
+        pthread_mutex_unlock(&SPEStateMutex);
+        close(SPESerialFd);
+        SPESerialFd = -1;
+        return false;
+    }
+    SPEThreadStarted = true;
+
+    printf("SPE amp CAT handler active on %s\n", path);
+    return true;
+}
+
+
+//
+// ShutdownSPEAmpHandler()
+// Signal the thread to stop, wait briefly for it to exit, then close
+// the serial port.
+//
+void ShutdownSPEAmpHandler(void)
+{
+    if (!SPEAmpActive)
+        return;
+
+    pthread_mutex_lock(&SPEStateMutex);
+    SPEAmpActive = false;
+    pthread_mutex_unlock(&SPEStateMutex);
+
+    if (SPESerialFd != -1)
+        close(SPESerialFd);
+
+    if (SPEThreadStarted)
+    {
+        pthread_join(SPEThread, NULL);
+        SPEThreadStarted = false;
+    }
+
+    SPESerialFd = -1;
+}
+
+
+//
+// SetSPEAmpTXFrequency()
+// Convert the DUC delta-phase word to Hz and cache it for the response thread.
+// Called from InHighPriority.c alongside SetAriesTXFrequency().
+//
+void SetSPEAmpTXFrequency(uint32_t NewFreqDeltaPhase)
+{
+    uint32_t freq_hz;
+
+    if(!SPEAmpActive)
+        return;
+
+    freq_hz = (uint32_t)((double)NewFreqDeltaPhase * SPE_DELTAPHASE_TO_HZ + 0.5);
+    pthread_mutex_lock(&SPEStateMutex);
+    SPETXFreq_Hz = freq_hz;
+    pthread_mutex_unlock(&SPEStateMutex);
+}
+
+
+void SetSPEAmpTXState(bool IsTX)
+{
+    if(!SPEAmpActive)
+        return;
+
+    pthread_mutex_lock(&SPEStateMutex);
+    SPETXState = IsTX;
+    pthread_mutex_unlock(&SPEStateMutex);
+}

--- a/sw_projects/P2_app/SPEAmpControl.h
+++ b/sw_projects/P2_app/SPEAmpControl.h
@@ -1,0 +1,40 @@
+/////////////////////////////////////////////////////////////
+//
+// Saturn project: Artix7 FPGA + Raspberry Pi4 Compute Module
+// PCI Express interface from linux on Raspberry pi
+// this application uses C code to emulate HPSDR protocol 2
+//
+// copyright Laurence Barker November 2021
+// licenced under GNU GPL3
+//
+// SPEAmpControl.h:
+//
+// Kenwood TS-2000 CAT emulation for SPE Expert linear amplifiers.
+// Enable with -e /dev/ttyUSBx (optional :baud suffix, default 9600).
+//
+//////////////////////////////////////////////////////////////
+
+#ifndef __SPEAmpControl_h
+#define __SPEAmpControl_h
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// true while the SPE amp shim is running
+extern bool SPEAmpActive;
+
+
+// open serial port and start CAT listener thread; PathAndBaud is "path" or "path:baud"
+bool InitialiseSPEAmpHandler(const char *PathAndBaud);
+
+// signal the listener thread to stop and wait for it to exit
+void ShutdownSPEAmpHandler(void);
+
+// update TX frequency from the DUC delta-phase word
+void SetSPEAmpTXFrequency(uint32_t NewFreqDeltaPhase);
+
+// update TX/RX state used in IF responses
+void SetSPEAmpTXState(bool IsTX);
+
+
+#endif  // __SPEAmpControl_h

--- a/sw_projects/P2_app/p2app.c
+++ b/sw_projects/P2_app/p2app.c
@@ -63,6 +63,7 @@
 #include "cathandler.h"
 #include "LDGATU.h"
 #include "AriesATU.h"
+#include "SPEAmpControl.h"
 #include "frontpanelhandler.h"
 #include "GanymedePAControl.h"
 
@@ -146,6 +147,8 @@ bool UseControlPanel = false;               // true if to use a control panel
 bool UseGanymede = false;                   // true if to use Ganymede PA protection
 bool UseLDGATU = false;                     // true if to use an LDG ATU via CAT
 bool UseAriesATU = false;                   // true if to use an Aries ATU
+bool UseSPEAmp = false;                   // true if to emulate Kenwood CAT for SPE amp
+char SPEAmpDevice[160] = "";             // SPE amp serial device path (and optional :baud)
 uint32_t LODebugDDC1Frequency;              // -x debug mode: LO frequency for DDC1
 bool InterleavedDDCDebugMode = false;       // true if interleaved DDC for debug are allowed
 
@@ -385,6 +388,8 @@ void Shutdown()
     ShutdownFrontPanelHandler();
   if(UseAriesATU)
     ShutdownAriesHandler();
+  if(UseSPEAmp)
+    ShutdownSPEAmpHandler();
 
   close(SocketData[0].Socketid);                          // close incoming data socket
   sem_destroy(&DDCInSelMutex);
@@ -535,7 +540,7 @@ int main(int argc, char *argv[])
 // option string needs a colon after each option letter that has a parameter after it
 // and it has a leading colon to suppress error messages
 //
-  while((CmdOption = getopt(argc, argv, ":a:i:f:x:m:sdphg")) != -1)
+  while((CmdOption = getopt(argc, argv, ":a:e:i:f:x:m:sdphg")) != -1)
   {
     switch(CmdOption)
     {
@@ -544,6 +549,8 @@ int main(int argc, char *argv[])
         printf("optional arguments:\n");
         printf("-a LDG        control TUNE for LDG ATU\n");
         printf("-a Aries      control TUNE for Aries ATU\n");
+        printf("-e <tty>      emulate Kenwood CAT for SPE Expert amp (e.g. /dev/ttyUSB0)\n");
+        printf("              optionally append :baudrate, e.g. /dev/ttyUSB0:4800 (default 9600)\n");
         printf("-f <frequency in Hz> turns on test source for all DDCs\n");
         printf("-g            enables PA protection (G2-1k only)\n");
         printf("-i saturn     board responds as board id = Saturn\n");
@@ -555,6 +562,12 @@ int main(int argc, char *argv[])
         printf("-p            drive G2 control panel\n");
         printf("-x            dubin mode to allow interleaved DDC on different frquencies\n");
         return EXIT_SUCCESS;
+        break;
+
+      case 'e':
+        strncpy(SPEAmpDevice, optarg, sizeof(SPEAmpDevice) - 1);
+        SPEAmpDevice[sizeof(SPEAmpDevice) - 1] = '\0';
+        UseSPEAmp = true;
         break;
 
       case 'a':
@@ -668,6 +681,15 @@ int main(int argc, char *argv[])
 //
   if(UseAriesATU)
     InitialiseAriesHandler();
+
+//
+// startup SPE Expert amp CAT emulation if requested
+//
+  if(UseSPEAmp)
+  {
+    if(!InitialiseSPEAmpHandler(SPEAmpDevice))
+      printf("SPE amp CAT: failed to start - check device path and permissions\n");
+  }
 
 //
 // startup Ganymede handler if needed

--- a/sw_projects/P2_app/serialport.h
+++ b/sw_projects/P2_app/serialport.h
@@ -45,6 +45,15 @@ typedef enum
 
 
 //
+// open and configure a serial port for read/write access.
+// DeviceName: device path (e.g. "/dev/ttyUSB0")
+// Baud: termios speed constant (e.g. B9600)
+// Returns the file descriptor on success, -1 on failure.
+//
+int OpenSerialPort(char* DeviceName, unsigned int Baud);
+
+
+//
 // send a string to the serial port
 //
 void SendStringToSerial(int Device, char* Message);


### PR DESCRIPTION
Adds SPE Expert amp CAT emulation to p2app via a new `-e` option.

When `-e <tty>` or `-e <tty>:<baud>` is specified, p2app opens the given serial port and responds to `IF;` and `FA;` queries with the current TX frequency (from the DUC delta-phase accumulator) and TX/RX state.

Usage:
`./p2app -e /dev/ttyUSB0`
`./p2app -e /dev/ttyUSB0:4800`

Tested only with an SPE Expert 1.3K-FA. Should work with other SPE Expert amps that use the same CAT protocol, but I can't confirm that.

This lets the Pi feed frequency information to the amp without a separate serial cable, USB-over-IP setup, or an extra CAT port from Thetis or piHPSDR.
