### PR TITLE
fix(xdma): use ccflags-y so the driver builds on Linux 6.15+

### DIFF
--- a/linuxdriver/xdma/Makefile
+++ b/linuxdriver/xdma/Makefile
@@ -14,9 +14,9 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
-#EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
-#EXTRA_CFLAGS += -DINTERNAL_TESTING
+ccflags-y := -I$(topdir)/include $(XVC_FLAGS)
+#ccflags-y += -D__LIBXDMA_DEBUG__
+#ccflags-y += -DINTERNAL_TESTING
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o


### PR DESCRIPTION
### Problem

On current kernels the XDMA driver does not build:

```
$ cd ~/github/Saturn/linuxdriver/xdma && make
  CC [M]  libxdma.o
libxdma.c:32:10: fatal error: libxdma_api.h: No such file or directory
   32 | #include "libxdma_api.h"
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```

The error is misleading — the header is not missing. It is present at
`linuxdriver/include/libxdma_api.h`, exactly where the Makefile expects it.

### Cause

`linuxdriver/xdma/Makefile` sets the include path via `EXTRA_CFLAGS`:

```make
EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
```

Kbuild removed support for the legacy `EXTRA_*FLAGS` variables in
[`e966ad0edd00`](https://git.kernel.org/linus/e966ad0edd00) *("kbuild: remove EXTRA_\*FLAGS
support")*, first released in **v6.15-rc1**. They had been deprecated since 2007, when
`f77bf01425b1` introduced `ccflags-y`, `asflags-y` and `ldflags-y`.

Kbuild does not warn about the now-unknown variable, so the `-I` flag is silently discarded
and the compiler never sees the include directory. Any out-of-tree module still using
`EXTRA_CFLAGS` for its include path breaks the same way — for example
[Ubuntu bug #2111898](https://bugs.launchpad.net/ubuntu/+source/broadcom-sta/+bug/2111898),
"Failed to build against linux >= 6.15".

Confirmed on the 6.18 headers — `EXTRA_CFLAGS` appears nowhere in kbuild, while
`scripts/Makefile.lib` reads `ccflags-y`:

```
$ grep -rn EXTRA_CFLAGS /usr/src/linux-headers-6.18.39+rpt-common-rpi/scripts/
(no matches)
```

### Fix

One variable rename. `ccflags-y` has been the supported spelling since 2007, so this builds
on old and new kernels alike — no version conditional needed.

```diff
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
-#EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
-#EXTRA_CFLAGS += -DINTERNAL_TESTING
+ccflags-y := -I$(topdir)/include $(XVC_FLAGS)
+#ccflags-y += -D__LIBXDMA_DEBUG__
+#ccflags-y += -DINTERNAL_TESTING
```

The commented-out debug lines are converted too, so they still work if someone uncomments
them.

### On `topdir`

`topdir := $(shell cd $(src)/.. && pwd)` looks like it might be affected by the kbuild
change to `$(src)` semantics for external modules, but it is fine. Instrumented on 6.18:

```
DIAG src=[./.] M=[/home/ve7scc/github/Saturn/linuxdriver/xdma] obj=[.]
     topdir=[/home/ve7scc/github/Saturn/linuxdriver]
```

`topdir` resolves correctly, so no change is needed there.

### Testing

| | |
|---|---|
| Hardware | Raspberry Pi Compute Module 5 (BCM2712), ANAN G2 control module |
| OS | Raspberry Pi OS Trixie (Debian 13) |
| Kernel | `6.18.39+rpt-rpi-2712` |

Before: build fails as above.
After:

```
  LD [M]  xdma.ko
$ sudo make install && sudo depmod -A && sudo modprobe xdma
$ dmesg | grep xdma
xdma:xdma_mod_init: Xilinx XDMA Reference Driver xdma v2020.1.8
xdma:xdma_mod_init: desc_blen_max: 0xfffffff/268435455, timeout: h2c 10 c2h 10 sec.
```

Only warnings remain (pre-existing `-Wmissing-prototypes`). Not regression-tested on a
pre-6.15 kernel, but `ccflags-y` has been supported since 2007, so no behaviour change is
expected there.


---

Full write-up of this migration, including the evidence behind this change, the working
`config.txt`, and the other issues met along the way: https://github.com/tcpreplay-dev/anan-g2-cm5-migration
(CC0 — reuse anything from it, upstream included.)
