### PR TITLE
fix(config): declare both DSI instances for the 8 inch panel on CM5

### DIFF
--- a/scripts/installfromscratch/Trixieconfig/cm5_8inch_config.txt
+++ b/scripts/installfromscratch/Trixieconfig/cm5_8inch_config.txt
@@ -56,6 +56,19 @@ dtparam=uart0=on
 #enable uart2
 dtoverlay=uart2-pi5
 
-#enable waveshare 8" LCD with i2c1
-dtoverlay=vc4-kms-dsi-waveshare-panel,8_0_inch,i2c1
+#enable waveshare 8" LCD
+#On a G2 the panel's video and its I2C control are reached through different DSI
+#instances, so both must be declared. With only ,dsi0 the I2C works (panel init,
+#backlight and touch are all fine) but there is no image. With only ,i2c1, or with
+#no modifier, the video is on the right port but nothing answers on the I2C, so the
+#panel is never initialised. Declaring both supplies each half from the instance
+#that has it. Apply with a cold power cycle; a warm reboot behaves differently.
+dtoverlay=vc4-kms-dsi-waveshare-panel,8_0_inch,i2c0,dsi1
+dtoverlay=vc4-kms-dsi-waveshare-panel,8_0_inch,i2c1,dsi0
 usb_max_current_enable=1
+
+#Panel and front-panel GPIO setup, as used by the factory CM4 configuration.
+#Without gpio=15 the panel controller can fail its init write at boot:
+#  ws_touchscreen 10-0045: I2C write failed: -121
+gpio=15=op,dh
+gpio=4-13,16-27=ip,pu


### PR DESCRIPTION
### Problem

`cm5_8inch_config.txt` does not bring up the 8 inch panel on an ANAN G2 with a CM5. The screen
stays black.

### Cause

On a G2 the panel's **video** and its **I2C control** are reached through *different DSI
instances*, so no single overlay line can work. Both failure modes were confirmed on hardware:

**With `,dsi0` alone** — the I2C side is correct and everything on it works:

```
Goodix-TS 10-0014: ID 9271, version: 1060
input: Goodix Capacitive TouchScreen ... /i2c-10/10-0014/input/input5
```

Panel controller responds at `10-0045`, backlight responds to brightness changes, no I2C
errors. But there is no image — the video is on the other DSI port.

**With `,i2c1` as currently shipped, or with no modifier** — video is on the right port, but
nothing answers on the I2C at all:

```
ws_touchscreen 1-0045: I2C write failed: -121
Goodix-TS 1-0014: I2C communication failure: -121
Goodix-TS 1-0014: probe with driver Goodix-TS failed with error -121
```

so the panel is never initialised. Also black. (`-121` is `EREMOTEIO` — nothing on the bus.)

Note the overlay README describes `i2c1` as being for "the I2C1 wiring with jumper wires from
GPIOs 2&3", which is not how a G2 is wired.

### Fix

Declare both instances, so each half comes from whichever one has it:

```
dtoverlay=vc4-kms-dsi-waveshare-panel,8_0_inch,i2c0,dsi1
dtoverlay=vc4-kms-dsi-waveshare-panel,8_0_inch,i2c1,dsi0
```

This mirrors the dual-DSI pattern **W7GES** used to get the 7 inch panel working on a CM5,
reported in the *"TRIXIE is not yet supported"* thread on apache-sdr-users — credit to him for
the insight.

Also adds the two `gpio=` lines carried by the factory CM4 configuration and missing from the
CM5 files:

```
gpio=15=op,dh
gpio=4-13,16-27=ip,pu
```

Without `gpio=15` the panel controller can fail its initialisation write at boot
(`ws_touchscreen 10-0045: I2C write failed: -121`).

### Notes for anyone testing this

- **Apply with a cold power cycle**, not `reboot`. Warm reboots behave differently and can
  leave the panel dark.
- One harmless side effect: the instance with no hardware on its bus logs
  `ws_touchscreen 0-0045: I2C write failed: -121` every boot. The working controller is on bus
  10 and is silent.
- The dual-DSI setup creates **two DRM outputs**, both `connected` (`DSI-1` at `0,0`, `DSI-2`
  at `1280,0`). The image is on `DSI-2`, so touch needs an explicit mapping or touches land on
  the blank half:

  ```xml
  <touch deviceName="Goodix Capacitive TouchScreen" mapToOutput="DSI-2" mouseEmulation="yes" />
  ```

  in `~/.config/labwc/rc.xml` (note: root element is `<openbox_config>`, and labwc uses the
  first `rc.xml` it finds, so copy the system file and add to it).
- **Both outputs must stay enabled.** Disabling either one blanks the panel, so the phantom
  output cannot be tidied away.
- The **taskbar** also lands on the phantom: `wf-panel-pi` picks its output when it starts, and
  at login that is before the outputs have settled. The `monitor=` setting does not help. A
  toggle plus panel restart from `~/.config/labwc/autostart` fixes it — but put only additions
  in that file, since labwc runs *both* autostart files.

These are user-config matters rather than anything this file can fix, but they are the
immediate next questions anyone applying it will hit.

### Testing

| | |
|---|---|
| Radio | ANAN G2 Ultra, Waveshare 8inch DSI LCD (C), 1280×800 |
| Module | Raspberry Pi CM5, 8 GB / 32 GB eMMC |
| OS | Raspberry Pi OS Trixie |
| Kernel | `6.18.39+rpt-rpi-2712` |

Display and touchscreen both working, verified across a cold power cycle.

I have not been able to test the 7 inch variant, so `cm5_7inch_config.txt` is left alone — but
it carries an `i2c0` parameter that does not appear in the overlay's parameter list at all,
which may be worth a look.


---

Full write-up of this migration, including the evidence behind this change, the working
`config.txt`, and the other issues met along the way: https://github.com/tcpreplay-dev/anan-g2-cm5-migration
(CC0 — reuse anything from it, upstream included.)

